### PR TITLE
Update AGRegistrationPage to differentiate data sharing consent based…

### DIFF
--- a/src/app/ag/[id]/register/page.tsx
+++ b/src/app/ag/[id]/register/page.tsx
@@ -1271,7 +1271,10 @@ export default function AGRegistrationPage() {
                                         />
                                         <div className="grid gap-1.5 leading-none">
                                             <Label htmlFor="autorizacao" className="text-sm font-medium leading-relaxed">
-                                                Autorizo o compartilhamento de meus dados (nome completo e email) para os patrocinadores do evento. *
+                                                {assembly.type === "AGE" 
+                                                    ? "Autorizo o processamento dos meus dados para fins de inscrição e monitorização do evento. *"
+                                                    : "Autorizo o compartilhamento de meus dados (nome completo e email) para os patrocinadores do evento. *"
+                                                }
                                             </Label>
                                             <p className="text-xs text-gray-600">
                                                 Esta autorização é necessária para a participação no evento.


### PR DESCRIPTION
… on assembly type

- Modified the consent label in the registration form to reflect different messaging for AGE assemblies versus other types, enhancing clarity for users regarding data processing and sharing.
- Ensured that the updated text aligns with the specific requirements of the assembly type, improving user understanding of data usage.