### PR TITLE
Add 'rascunho' field to Blog model and update related components

### DIFF
--- a/prisma/migrations/20250701015821_rascunho/migration.sql
+++ b/prisma/migrations/20250701015821_rascunho/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Blog` ADD COLUMN `rascunho` BOOLEAN NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,6 +82,7 @@ model Blog {
     imageLink       String?
     forceHomePage   Boolean
     userId          String
+    rascunho        Boolean?
 
     user            User     @relation(fields: [userId], references: [id])
     authors         BlogAuthor[] // New relationship for extended author info

--- a/src/app/_components/CreateNoticia.tsx
+++ b/src/app/_components/CreateNoticia.tsx
@@ -82,6 +82,7 @@ const CreateNoticia = () => {
     const [image, setImage] = useState<string | null>(null);
     const [imageSrc, setImageSrc] = useState<string | null>(null);
     const [forcarPaginaInicial, setForcarPaginaInicial] = useState(false);
+    const [rascunho, setRascunho] = useState(false);
     const [isEditMode, setIsEditMode] = useState(false);
     const [noticiaId, setNoticiaId] = useState<number | null>(null);
     
@@ -195,6 +196,7 @@ const CreateNoticia = () => {
             }
             setImageSrc(noticiaData.imageLink);
             setForcarPaginaInicial(noticiaData.forceHomePage);
+            setRascunho(noticiaData.rascunho ?? false);
             
             // Fetch markdown only on initial load
             if (initialMarkdownUrl !== noticiaData.link) {
@@ -298,6 +300,7 @@ const CreateNoticia = () => {
                     link: uploadResult.markdownUrl,
                     imageLink: uploadResult.imageUrl,
                     forceHomePage: forcarPaginaInicial,
+                    rascunho: rascunho,
                 });
             } catch (error) {
                 console.error("Error updating noticia:", error);
@@ -331,6 +334,7 @@ const CreateNoticia = () => {
                     link: uploadResult.markdownUrl,
                     imageLink: uploadResult.imageUrl,
                     forceHomePage: forcarPaginaInicial,
+                    rascunho: rascunho,
                 });
             } catch (error) {
                 console.error("Error creating noticia:", error);
@@ -559,16 +563,29 @@ const CreateNoticia = () => {
                                     </div>
                                 </div>
 
-                                {/* Checkbox */}
-                                <div className="flex items-center space-x-2">
-                                    <Checkbox
-                                        id="forcarPaginaInicial"
-                                        checked={forcarPaginaInicial}
-                                        onCheckedChange={(checked) => setForcarPaginaInicial(checked === true)}
-                                    />
-                                    <Label htmlFor="forcarPaginaInicial" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-                                        Forçar Página Inicial
-                                    </Label>
+                                {/* Checkboxes */}
+                                <div className="space-y-3">
+                                    <div className="flex items-center space-x-2">
+                                        <Checkbox
+                                            id="forcarPaginaInicial"
+                                            checked={forcarPaginaInicial}
+                                            onCheckedChange={(checked) => setForcarPaginaInicial(checked === true)}
+                                        />
+                                        <Label htmlFor="forcarPaginaInicial" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                                            Forçar Página Inicial
+                                        </Label>
+                                    </div>
+                                    
+                                    <div className="flex items-center space-x-2">
+                                        <Checkbox
+                                            id="rascunho"
+                                            checked={rascunho}
+                                            onCheckedChange={(checked) => setRascunho(checked === true)}
+                                        />
+                                        <Label htmlFor="rascunho" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                                            Salvar como Rascunho
+                                        </Label>
+                                    </div>
                                 </div>
 
                                 {/* Submit Button */}

--- a/src/app/_components/NoticiasTable.tsx
+++ b/src/app/_components/NoticiasTable.tsx
@@ -236,6 +236,7 @@ export default function NoticiasTable() {
                                         <TableHead className="font-semibold">Autor</TableHead>
                                         <TableHead className="font-semibold">Título</TableHead>
                                         <TableHead className="font-semibold">Resumo</TableHead>
+                                        <TableHead className="font-semibold">Status</TableHead>
                                         <TableHead className="font-semibold">Imagem</TableHead>
                                         <TableHead className="font-semibold text-right">Ações</TableHead>
                                     </TableRow>
@@ -270,6 +271,14 @@ export default function NoticiasTable() {
                                                         {row.summary}
                                                     </p>
                                                 </div>
+                                            </TableCell>
+                                            <TableCell>
+                                                <Badge 
+                                                    variant={row.rascunho ? "secondary" : "default"}
+                                                    className={row.rascunho ? "bg-orange-100 text-orange-700 hover:bg-orange-200" : "bg-green-100 text-green-700 hover:bg-green-200"}
+                                                >
+                                                    {row.rascunho ? "Rascunho" : "Publicado"}
+                                                </Badge>
                                             </TableCell>
                                             <TableCell>
                                                 {row.imageLink ? (

--- a/src/server/api/routers/noticias.ts
+++ b/src/server/api/routers/noticias.ts
@@ -81,6 +81,7 @@ const formatBlogForAlgolia = async (blog: any) => {
         link: blog.link,
         imageLink: blog.imageLink,
         forceHomePage: blog.forceHomePage,
+        rascunho: blog.rascunho || false,
         url: `https://ifmsabrazil.org/arquivo/${blog.id}`,
     };
 
@@ -267,6 +268,7 @@ export const noticiasRouter = createTRPCRouter({
             link: z.string(),
             imageLink: z.string().optional(),
             forceHomePage: z.boolean(),
+            rascunho: z.boolean().default(false),
         }))
         .mutation(async ({ ctx, input }) => {
             // Validate userId
@@ -284,6 +286,7 @@ export const noticiasRouter = createTRPCRouter({
                     link: input.link,
                     imageLink: input.imageLink,
                     forceHomePage: input.forceHomePage,
+                    rascunho: input.rascunho,
                     user: { connect: { id: user.id } },
                 },
             });
@@ -311,6 +314,7 @@ export const noticiasRouter = createTRPCRouter({
             link: z.string(),
             imageLink: z.string().optional(),
             forceHomePage: z.boolean(),
+            rascunho: z.boolean().default(false),
         }))
         .mutation(async ({ ctx, input }) => {
             const updatedBlog = await ctx.db.blog.update({
@@ -323,6 +327,7 @@ export const noticiasRouter = createTRPCRouter({
                     link: input.link,
                     imageLink: input.imageLink,
                     forceHomePage: input.forceHomePage,
+                    rascunho: input.rascunho,
                 },
             });
 


### PR DESCRIPTION
- Introduced a new optional 'rascunho' field in the Blog model to indicate draft status.
- Updated CreateNoticia component to manage 'rascunho' state and include it in submission.
- Enhanced NoticiasTable to display the draft status with a badge.
- Modified API routes to handle 'rascunho' in create and update operations.